### PR TITLE
NVSHAS-7653 fixed unreachable code, added logic for nvd override.

### DIFF
--- a/updater/metadata_fetchers/nvd/nvd.go
+++ b/updater/metadata_fetchers/nvd/nvd.go
@@ -311,9 +311,9 @@ func (fetcher *NVDMetadataFetcher) AddMetadata(v *updater.VulnerabilityWithLock)
 				PublishedDate:    v.Vulnerability.IssuedDate,
 				LastModifiedDate: v.Vulnerability.LastModDate,
 			}
+		} else {
+			found = true
 		}
-
-		found = true
 
 		// Create Metadata map if necessary.
 		if v.Metadata == nil {
@@ -355,7 +355,7 @@ func (fetcher *NVDMetadataFetcher) AddMetadata(v *updater.VulnerabilityWithLock)
 	// 	log.WithFields(log.Fields{"v": v.Vulnerability}).Error("================")
 	// }
 
-	if found {
+	if found && (maxV3 > 0 || maxV2 > 0) {
 		// log.WithFields(log.Fields{"cve": v.Name, "maxV2": maxV2, "maxV3": maxV3}).Info()
 
 		// For NVSHAS-4709, always set the severity by CVSS scores
@@ -373,7 +373,6 @@ func (fetcher *NVDMetadataFetcher) AddMetadata(v *updater.VulnerabilityWithLock)
 			v.Vulnerability.Description = getCveDescription(v.Vulnerability.Name)
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
found was always true, causing unreachable code. Added logic so that when nvd data exists but has score of 0 we use the original severity instead. This prevents pruning entries that are missing score in nvd.