### PR TITLE
NVSHAS-8675 add support for mariner 2.0 and new debian/ubuntu names.

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -182,6 +182,9 @@ var UbuntuReleasesMapping = map[string]string{
 	"impish":           "21.10",
 	"jammy":            "22.04",
 	"kinetic":          "22.10",
+	"lunar":            "23.04",
+	"mantic":           "23.10",
+	"noble":            "24.04",
 }
 
 var DebianReleasesMapping = map[string]string{
@@ -194,6 +197,7 @@ var DebianReleasesMapping = map[string]string{
 	"bullseye": "11",
 	"bookworm": "12",
 	"trixie":   "13",
+	"forky":    "14",
 	"sid":      "unstable",
 
 	// Class names

--- a/updater/fetchers/mariner/mariner.go
+++ b/updater/fetchers/mariner/mariner.go
@@ -18,12 +18,15 @@ import (
 
 const (
 	marinerFolder = "mariner-vulnerability"
-	marinerFile   = "cbl-mariner-1.0-oval.xml"
 	notapplicable = "not applicable"
 )
 
 var (
 	ignoredCriterions = []string{}
+	marinerFiles      = []string{
+		"cbl-mariner-1.0-oval.xml",
+		"cbl-mariner-2.0-oval.xml",
+	}
 )
 
 type MarinerFetcher struct{}
@@ -107,23 +110,24 @@ func (fetcher *MarinerFetcher) FetchUpdate() (resp updater.FetcherResponse, err 
 	log.Info("fetching mariner vulnerabilities")
 	var reader io.Reader
 
-	//Load file
-	file, err := os.Open(fmt.Sprintf("%s/%s/%s", common.CVESourceRoot, marinerFolder, marinerFile))
-	if err != nil {
-		return resp, err
-	}
-	reader = bufio.NewReader(file)
+	//Load each file
+	for _, marinerFile := range marinerFiles {
+		file, err := os.Open(fmt.Sprintf("%s/%s/%s", common.CVESourceRoot, marinerFolder, marinerFile))
+		if err != nil {
+			return resp, err
+		}
+		reader = bufio.NewReader(file)
 
-	vulns, err := parseMarinerOval(reader)
-	if err != nil {
-		return resp, err
-	}
+		vulns, err := parseMarinerOval(reader)
+		if err != nil {
+			return resp, err
+		}
 
-	// Collect vulnerabilities.
-	for _, v := range vulns {
-		resp.Vulnerabilities = append(resp.Vulnerabilities, v)
+		// Collect vulnerabilities.
+		resp.Vulnerabilities = append(resp.Vulnerabilities, vulns...)
+
+		log.WithFields(log.Fields{"Vulnerabilities": len(resp.Vulnerabilities)}).Info("fetching mariner done")
 	}
-	log.WithFields(log.Fields{"Vulnerabilities": len(resp.Vulnerabilities)}).Info("fetching mariner done")
 	return resp, nil
 }
 


### PR DESCRIPTION
Add logic to handle multiple mariner files and add new debian and ubuntu name mappings.