### PR TITLE
NVSHAS-9044 fix issue with "is installed" and "is enabled"

### DIFF
--- a/updater/fetchers/rhel2/rhel.go
+++ b/updater/fetchers/rhel2/rhel.go
@@ -636,10 +636,8 @@ func toFeatureVersions(ros int, rhsa, cvename string, criteria criteria) []commo
 					featureVersion.Feature.Name = strings.TrimSpace(c.Comment[:a])
 				}
 				featureVersion.Version = common.MinVersion
-			} else {
-				if a := strings.Index(c.Comment, " is installed"); a > 0 {
-					featureVersion.Feature.Name = strings.TrimSpace(c.Comment[:a])
-				}
+			} else if strings.Contains(c.Comment, " is installed") {
+				featureVersion.Feature.Name = strings.TrimSpace(c.Comment[:strings.Index(c.Comment, " is installed")])
 				featureVersion.Version = common.MaxVersion
 			}
 		}


### PR DESCRIPTION
"is installed" and "is enabled" used the same case, causing some data to be overwritten with MAXV for version.