### PR TITLE
fix: add CVE-2024-4109 to withdrawn cves

### DIFF
--- a/updater/fetchers/apps/apps.go
+++ b/updater/fetchers/apps/apps.go
@@ -20,7 +20,7 @@ var vulCache utils.Set = utils.NewSet()
 var cveCalibrate map[string][]common.AppModuleVersion = make(map[string][]common.AppModuleVersion)
 
 // Sometimes source doesn't remove withdrawn CVEs
-var withdrawnCVEs = map[string]struct{}{"CVE-2021-23334": {}}
+var withdrawnCVEs = map[string]struct{}{"CVE-2021-23334": {}, "CVE-2024-4109": {}}
 
 // This is a workaround to use import to control app db generation
 type AppFetcher struct{}


### PR DESCRIPTION
### Summary

- CVE has been marked as a False Positive. The vulnerability CVE-2024-4109 is meant to be removed according to the sources below.:

1. NIST: https://nvd.nist.gov/vuln/detail/CVE-2024-4109
2. GitHub CVE: https://github.com/advisories/GHSA-22c5-cpvr-cfvq