### PR TITLE
fix: support esm release for ububtu fectcher.

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -186,6 +186,10 @@ var UbuntuReleasesMapping = map[string]string{
 	"lunar":            "23.04",
 	"mantic":           "23.10",
 	"noble":            "24.04",
+	"esm-apps/bionic":  "18.04",
+	"esm-apps/focal":   "20.04",
+	"esm-apps/jammy":   "22.04",
+	"esm-apps/noble":   "24.04",
 }
 
 var DebianReleasesMapping = map[string]string{


### PR DESCRIPTION
### Summary

- Added support for parsing esm-apps/* versions to correctly extract the ffmpeg version.
- The vulnerability CVE-2023-49502 is fixed in esm-apps/jammy_ffmpeg: released (7:4.4.2-0ubuntu0.22.04.1+esm4).
- The customer is using esm-apps/jammy_ffmpeg: released (7:4.4.2-0ubuntu0.22.04.1+esm5), which we currently do not explicitly parse as esm5, but we treat it as equivalent and consider the issue resolved.