### PR TITLE
fix: severity regix to fetch

### DIFF
--- a/updater/fetchers/apps/openssl.go
+++ b/updater/fetchers/apps/openssl.go
@@ -22,7 +22,7 @@ var cveRecordLinkRegexp = regexp.MustCompile(`="(.*) target(.*)>CVE Record`)
 var fixedVerRegexp = regexp.MustCompile(`Fixed in OpenSSL\s*\n*([0-9a-z\.\-\s]+)`)
 var affectedVerRegexp = regexp.MustCompile(`\(Affected\s+([0-9a-z\.\-,\s]+)\s*\)`)
 var verRegexp = regexp.MustCompile(`<li>from\s*\n*([0-9a-z\.\-\s]+) before\s*\n*([0-9a-z\.\-\s]+)<\/li>`) // ungreedy
-var severityRegexp = regexp.MustCompile(`<dt[^>]*>\s*Severity\s*</dt>\s*<dd[^>]*>\s*([A-Za-z]+)\s*</dd>`)
+var severityRegexp = regexp.MustCompile(`<span[^>]*>\s*Severity\s*</span>\s*</div>\s*<div[^>]*>\s*([A-Za-z]+)\s*</div>`)
 var descriptionRegexp = regexp.MustCompile(`<p>([a-zA-Z[\S+\n\r\s]+)<\/p>`)
 
 // FetchUpdate gets vulnerability updates from the openssl.


### PR DESCRIPTION
### Summary
- the severity format changes from the openssl side, we need to update our regix to adapt it.