### PR TITLE
fix: add init for set CvesIncludeGoVuln to avoid panic

### DIFF
--- a/updater/fetchers/ubuntu/ubuntu.go
+++ b/updater/fetchers/ubuntu/ubuntu.go
@@ -83,7 +83,9 @@ type UbuntuFetcher struct {
 }
 
 func init() {
-	updater.RegisterFetcher("ubuntu", &UbuntuFetcher{})
+	updater.RegisterFetcher("ubuntu", &UbuntuFetcher{
+		CvesIncludeGoVuln: utils.NewSet(),
+	})
 }
 
 // FetchUpdate gets vulnerability updates from the Ubuntu CVE Tracker.


### PR DESCRIPTION
### Summary
- miss initialize the UbuntuFetcher trigger the build panic.