### PR TITLE
fix: add fixver in go vuls

### DIFF
--- a/updater/fetchers/apps/govuln.go
+++ b/updater/fetchers/apps/govuln.go
@@ -174,6 +174,10 @@ func parseAffectedRanges(affected *osvschema.Affected, appVul *common.AppModuleV
 					OpCode:  "andlt",
 					Version: event.Fixed,
 				})
+				appVul.FixedVer = append(appVul.FixedVer, common.AppModuleVersion{
+					OpCode:  "andlt",
+					Version: event.Fixed,
+				})
 			}
 		}
 	}
@@ -220,6 +224,10 @@ func parseAffectedRanges(affected *osvschema.Affected, appVul *common.AppModuleV
 
 			if event.Fixed != "" {
 				appVul.AffectedVer = append(appVul.AffectedVer, common.AppModuleVersion{
+					OpCode:  "andlt",
+					Version: event.Fixed,
+				})
+				appVul.FixedVer = append(appVul.FixedVer, common.AppModuleVersion{
 					OpCode:  "andlt",
 					Version: event.Fixed,
 				})


### PR DESCRIPTION
### Summary
- Add fixver in go vuls to show the fix version in report.