### PR TITLE
fix: ensure the .jar suffix is clean up properly

### DIFF
--- a/updater/fetchers/apps/ghsa.go
+++ b/updater/fetchers/apps/ghsa.go
@@ -24,6 +24,8 @@ const (
 	phpDataFile    = "github/php.data.gz"
 )
 
+var jreRegex = regexp.MustCompile(`\.jre\d+`)
+
 type ghsaData struct {
 	ID      string `json:"id"`
 	Package struct {
@@ -70,6 +72,10 @@ func ghsaUpdate() error {
 	loadGHSAData(golangDataFile, "golang", "go:", false)
 	loadGHSAData(phpDataFile, "php", "php:", true)
 	return nil
+}
+
+func cleanupVersion(version string) string {
+	return jreRegex.ReplaceAllString(version, "")
 }
 
 func loadGHSAData(ghsaFile, app, prefix string, lowercase bool) error {
@@ -125,7 +131,7 @@ func loadGHSAData(ghsaFile, app, prefix string, lowercase bool) error {
 			moduleName = strings.ToLower(moduleName)
 		}
 		affectedVer := getVersion(r.AffectedVersion)
-		fixedVer := getVersion(r.PatchedVersion.Identifier)
+		fixedVer := getVersion(cleanupVersion(r.PatchedVersion.Identifier))
 		key := fmt.Sprintf("%s-%s", vulName, moduleName)
 
 		if v, ok := vmap[key]; !ok {

--- a/updater/fetchers/apps/ghsa_test.go
+++ b/updater/fetchers/apps/ghsa_test.go
@@ -1,0 +1,44 @@
+package apps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCleanupVersionOnly cleans up .jreXX version for now.
+func TestCleanupVersion(t *testing.T) {
+	testcases := []struct {
+		version  string
+		expected string
+	}{
+		{
+			version:  "1.0.0.jar",
+			expected: "1.0.0.jar",
+		},
+		{
+			version:  "1.0.0.war",
+			expected: "1.0.0.war",
+		},
+		{
+			version:  "1.0.0",
+			expected: "1.0.0",
+		},
+		{
+			version:  "1.0.0.jre11",
+			expected: "1.0.0",
+		},
+		{
+			version:  "1.0.0.jre17",
+			expected: "1.0.0",
+		},
+		{
+			version:  "1.0.0.jre21",
+			expected: "1.0.0",
+		},
+	}
+	for _, testcase := range testcases {
+		actual := cleanupVersion(testcase.version)
+		require.Equal(t, testcase.expected, actual)
+	}
+}


### PR DESCRIPTION
### Summary
- Currently the version may contains like jre11 or others, which pollute the version compare, creating a cleanup function to ensure the version is properly kept