### PR TITLE
fix: version should gteq not lt

### DIFF
--- a/updater/fetchers/apps/govuln.go
+++ b/updater/fetchers/apps/govuln.go
@@ -175,7 +175,7 @@ func parseAffectedRanges(affected *osvschema.Affected, appVul *common.AppModuleV
 					Version: event.Fixed,
 				})
 				appVul.FixedVer = append(appVul.FixedVer, common.AppModuleVersion{
-					OpCode:  "andlt",
+					OpCode:  "gteq",
 					Version: event.Fixed,
 				})
 			}
@@ -228,7 +228,7 @@ func parseAffectedRanges(affected *osvschema.Affected, appVul *common.AppModuleV
 					Version: event.Fixed,
 				})
 				appVul.FixedVer = append(appVul.FixedVer, common.AppModuleVersion{
-					OpCode:  "andlt",
+					OpCode:  "gteq",
 					Version: event.Fixed,
 				})
 			}


### PR DESCRIPTION
### Summary
- Currently showing the fix is <, which is confusing, replace with >= (gteq)