### PR TITLE
refactor: use OSV feed to replace the legacy single source

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Generate NeuVector vulnerability database
 | **OS based** |
 | Alpine | https://secdb.alpinelinux.org/ |
 | Amazon | https://alas.aws.amazon.com/ |
-| Chainguard | https://packages.cgr.dev/chainguard/security.json |
+| Chainguard | https://advisories.cgr.dev/chainguard/v2/osv|
 | Debian | https://security-tracker.debian.org/tracker/data/json |
 | Microsoft mariner | https://github.com/microsoft/CBL-MarinerVulnerabilityData |
 | Oracle OS | https://linux.oracle.com/oval/ |
@@ -19,7 +19,7 @@ Generate NeuVector vulnerability database
 | Red Hat/CentOS | https://www.redhat.com/security/data/oval/v2/ |
 | SUSE Linux | https://ftp.suse.com/pub/projects/security/oval/ |
 | Ubuntu | https://launchpad.net/ubuntu-cve-tracker |
-| Wolfi | https://packages.wolfi.dev/os/security.json |
+| Wolfi | https://advisories.cgr.dev/chainguard/v2/osv|
 | **Application based** |
 | .NET | https://github.com/advisories, https://www.cvedetails.com/vulnerability-list/vendor_id-26/ |
 | apache | https://www.cvedetails.com/vendor/45/Apache.html |

--- a/updater/fetchers/apps/govuln.go
+++ b/updater/fetchers/apps/govuln.go
@@ -148,24 +148,24 @@ func parseAffectedImports(affected *osvschema.Affected, appVul *common.AppModule
 	}
 }
 
-func loadZipFile(zipFile *zip.File) (*osvschema.Vulnerability, error) {
-	file, err := zipFile.Open()
+func loadOSVFeedEntry(feedEntry *zip.File) (*osvschema.Vulnerability, error) {
+	file, err := feedEntry.Open()
 	if err != nil {
-		log.Warnf("Could not read %s: %v", zipFile.Name, err)
+		log.Warnf("Could not read %s: %v", feedEntry.Name, err)
 		return nil, err
 	}
 	defer file.Close()
 
 	content, err := io.ReadAll(file)
 	if err != nil {
-		log.Warnf("Could not read %s: %v", zipFile.Name, err)
+		log.Warnf("Could not read %s: %v", feedEntry.Name, err)
 		return nil, err
 	}
 
 	var vulnerability osvschema.Vulnerability
 
 	if err := protojson.Unmarshal(content, &vulnerability); err != nil {
-		log.Warnf("%s is not a valid JSON file: %v", zipFile.Name, err)
+		log.Warnf("%s is not a valid JSON file: %v", feedEntry.Name, err)
 		return nil, err
 	}
 	return &vulnerability, nil
@@ -431,7 +431,7 @@ func loadGoOSVVulnerabilities() (map[string]*common.AppModuleVul, utils.Set, err
 	defer zipReader.Close()
 
 	for _, file := range zipReader.File {
-		vulnerability, err := loadZipFile(file)
+		vulnerability, err := loadOSVFeedEntry(file)
 		if err != nil {
 			log.WithFields(log.Fields{"file": file.Name, "error": err}).Warn("Failed to load Go OSV file")
 			continue

--- a/updater/fetchers/chainguard/chainguard.go
+++ b/updater/fetchers/chainguard/chainguard.go
@@ -1,129 +1,31 @@
 package chainguard
 
 import (
-	"encoding/json"
-	"io"
-	"net/http"
-	"regexp"
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 
-	"github.com/vul-dbgen/common"
 	"github.com/vul-dbgen/updater"
+	"github.com/vul-dbgen/updater/fetchers/chainguardv2"
 )
 
 const (
-	securityURL  = "https://packages.cgr.dev/chainguard/security.json"
-	cveURLPrefix = "https://cve.mitre.org/cgi-bin/cvename.cgi?name="
-	// Chainguard uses rolling releases, so we use a generic version identifier
-	chainguardVersion = "rolling"
+	chainguardEcosystem = "Chainguard"
+	chainguardNamespace = "chainguard:rolling"
 )
 
-var cveRegex = regexp.MustCompile(`^CVE-\d{4}-\d{4,}$`)
-
 type ChainguardFetcher struct{}
-
-type secDBData struct {
-	Packages []struct {
-		Pkg struct {
-			Name     string                     `json:"name"`
-			SecFixes map[string]json.RawMessage `json:"secfixes"`
-		} `json:"pkg"`
-	} `json:"packages"`
-}
 
 func init() {
 	updater.RegisterFetcher("chainguard", &ChainguardFetcher{})
 }
 
-func parseSecDB(body []byte, url string) ([]common.Vulnerability, error) {
-	var data secDBData
-	if err := json.Unmarshal(body, &data); err != nil {
-		log.WithError(err).WithFields(log.Fields{"url": url}).Warn("Failed to unmarshal chainguard db")
-		return nil, err
-	}
-
-	var vulns []common.Vulnerability
-	for _, pkg := range data.Packages {
-		for version, raw := range pkg.Pkg.SecFixes {
-			// Skip version "0" entries as they represent false positives
-			if version == "0" {
-				continue
-			}
-
-			ver, err := common.NewVersion(version)
-			if err != nil {
-				log.WithError(err).WithField("version", version).Warn("Failed to parse package version. skipping")
-				continue
-			}
-
-			var cves []string
-			if err = json.Unmarshal(raw, &cves); err != nil {
-				continue
-			}
-
-			for _, cveName := range cves {
-				// Filter out GHSA identifiers, only process CVEs
-				if !cveRegex.MatchString(cveName) {
-					continue
-				}
-
-				if year, err := common.ParseYear(cveName[4:]); err != nil {
-					log.WithField("cve", cveName).Warn("Unable to parse year from CVE name")
-					continue
-				} else if year < common.FirstYear {
-					continue
-				}
-
-				if s := strings.Index(cveName, " "); s != -1 {
-					cveName = cveName[:s]
-				}
-
-				var vuln common.Vulnerability
-				vuln.Name = cveName
-				vuln.Link = cveURLPrefix + cveName
-
-				featureVersion := common.FeatureVersion{
-					Feature: common.Feature{
-						Namespace: "chainguard:" + chainguardVersion,
-						Name:      pkg.Pkg.Name,
-					},
-					Version: ver,
-				}
-				vuln.FixedIn = append(vuln.FixedIn, featureVersion)
-
-				vulns = append(vulns, vuln)
-
-				common.DEBUG_VULN(&vuln, "chainguard")
-			}
-		}
-	}
-
-	return vulns, nil
-}
-
-func (u *ChainguardFetcher) downloadSecDB(url string) ([]common.Vulnerability, error) {
-	r, err := http.Get(url)
-	if err != nil {
-		log.WithError(err).WithFields(log.Fields{"url": url}).Error("Failed to download chainguard db")
-		return nil, err
-	}
-	body, _ := io.ReadAll(r.Body)
-	defer r.Body.Close()
-
-	return parseSecDB(body, url)
-}
-
 func (u *ChainguardFetcher) FetchUpdate() (resp updater.FetcherResponse, err error) {
 	log.WithField("package", "Chainguard").Info("Start fetching vulnerabilities")
 
-	// Download security.json
-	if vulns, err := u.downloadSecDB(securityURL); err == nil {
-		resp.Vulnerabilities = append(resp.Vulnerabilities, vulns...)
-	} else {
+	vulns, err := chainguardv2.FetchVulnerabilities(chainguardEcosystem, chainguardNamespace)
+	if err != nil {
 		return resp, err
 	}
+	resp.Vulnerabilities = append(resp.Vulnerabilities, vulns...)
 
 	log.WithFields(log.Fields{"Vulnerabilities": len(resp.Vulnerabilities)}).Info("fetching chainguard done")
 	return resp, nil

--- a/updater/fetchers/chainguardv2/chainguardv2.go
+++ b/updater/fetchers/chainguardv2/chainguardv2.go
@@ -1,0 +1,217 @@
+package chainguardv2
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/vul-dbgen/common"
+)
+
+const (
+	chainguardOSVZipPath = "chainguard/osv-v2.zip"
+	advisoryURL          = "https://advisories.cgr.dev/chainguard/v2/osv/%s.json"
+	cveURLPrefix         = "https://cve.mitre.org/cgi-bin/cvename.cgi?name="
+	chainguardNamespace  = "chainguard"
+	wolfiNamespace       = "wolfi"
+)
+
+type featureKey struct {
+	Name    string
+	Version string
+}
+
+// FetchVulnerabilities fetches and parses vulnerabilities from the Chainguard OSV v2 feed, filtering by the specified ecosystem and namespace.
+// Reference: https://github.com/chainguard-dev/vulnerability-scanner-support/blob/main/docs/osv_v2_feed.md
+func FetchVulnerabilities(targetEcosystem, targetNamespace string) ([]common.Vulnerability, error) {
+	namespaceName := targetNamespace
+	if i := strings.IndexByte(targetNamespace, ':'); i >= 0 {
+		namespaceName = targetNamespace[:i]
+	}
+
+	switch namespaceName {
+	case chainguardNamespace, wolfiNamespace:
+	default:
+		return nil, fmt.Errorf("unsupported namespace: %s", targetNamespace)
+	}
+
+	dataFile := fmt.Sprintf("%s%s", common.CVESourceRoot, chainguardOSVZipPath)
+	zipReader, err := zip.OpenReader(dataFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open Chainguard OSV v2 zip file %s: %w", dataFile, err)
+	}
+	defer zipReader.Close()
+
+	var vulnerabilities []common.Vulnerability
+	for _, file := range zipReader.File {
+		body, err := loadOSVFeedEntry(file)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"ecosystem": targetEcosystem,
+				"file":      file.Name,
+				"error":     err,
+			}).Warn("Failed to read Chainguard OSV v2 advisory")
+			continue
+		}
+
+		vulns, err := parseAdvisory(body, targetEcosystem, targetNamespace)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"ecosystem": targetEcosystem,
+				"file":      file.Name,
+				"error":     err,
+			}).Warn("Failed to parse Chainguard OSV v2 advisory")
+			continue
+		}
+		if len(vulns) > 0 {
+			vulnerabilities = append(vulnerabilities, vulns...)
+		}
+	}
+
+	return vulnerabilities, nil
+}
+
+func loadOSVFeedEntry(feedEntry *zip.File) ([]byte, error) {
+	file, err := feedEntry.Open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %s: %w", feedEntry.Name, err)
+	}
+	defer file.Close()
+
+	body, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", feedEntry.Name, err)
+	}
+	return body, nil
+}
+
+func extractCVEs(upstream []string) []string {
+	cves := make([]string, 0, len(upstream))
+	existCVE := make(map[string]struct{}, len(upstream))
+	for _, item := range upstream {
+		if !strings.HasPrefix(item, "CVE-") {
+			continue
+		}
+		if _, ok := existCVE[item]; ok {
+			continue
+		}
+		cves = append(cves, item)
+		existCVE[item] = struct{}{}
+	}
+	return cves
+}
+
+func extractFixedVersions(ranges []*osvschema.Range) []string {
+	fixedVersions := make([]string, 0)
+	existFixedVersion := make(map[string]struct{})
+
+	for _, r := range ranges {
+		if r.Type != osvschema.Range_ECOSYSTEM {
+			continue
+		}
+		for _, event := range r.Events {
+			if event.Fixed == "" {
+				continue
+			}
+			if _, ok := existFixedVersion[event.Fixed]; ok {
+				continue
+			}
+			fixedVersions = append(fixedVersions, event.Fixed)
+			existFixedVersion[event.Fixed] = struct{}{}
+		}
+	}
+
+	return fixedVersions
+}
+
+func parseAdvisory(body []byte, targetEcosystem, targetNamespace string) ([]common.Vulnerability, error) {
+	var adv osvschema.Vulnerability
+	if err := protojson.Unmarshal(body, &adv); err != nil {
+		return nil, err
+	}
+
+	// Keeps CVE only.
+	cves := extractCVEs(adv.Upstream)
+	if len(cves) == 0 {
+		return nil, nil
+	}
+	var published, modified time.Time
+	if adv.Published != nil {
+		published = adv.Published.AsTime()
+	}
+	if adv.Modified != nil {
+		modified = adv.Modified.AsTime()
+	}
+
+	advisoryLink := fmt.Sprintf(advisoryURL, adv.Id)
+
+	vulnMap := make(map[string]*common.Vulnerability, len(cves))
+	existFeatures := make(map[string]map[featureKey]struct{}, len(cves))
+	for _, cve := range cves {
+		link := cveURLPrefix + cve
+		if link == cveURLPrefix {
+			link = advisoryLink
+		}
+		vulnMap[cve] = &common.Vulnerability{
+			Name:        cve,
+			Link:        link,
+			IssuedDate:  published,
+			LastModDate: modified,
+			FixedIn:     make([]common.FeatureVersion, 0),
+		}
+		existFeatures[cve] = make(map[featureKey]struct{})
+	}
+
+	for _, affected := range adv.Affected {
+		if affected.Package.Ecosystem != targetEcosystem {
+			continue
+		}
+
+		for _, fixedVersion := range extractFixedVersions(affected.Ranges) {
+			ver, err := common.NewVersion(fixedVersion)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"ecosystem": targetEcosystem,
+					"package":   affected.Package.Name,
+					"version":   fixedVersion,
+					"advisory":  adv.Id,
+					"error":     err,
+				}).Warn("Failed to parse fixed version from Chainguard OSV v2 advisory")
+				continue
+			}
+
+			feature := common.FeatureVersion{
+				Feature: common.Feature{
+					Namespace: targetNamespace,
+					Name:      affected.Package.Name,
+				},
+				Version: ver,
+			}
+
+			key := featureKey{Name: affected.Package.Name, Version: fixedVersion}
+			for _, cve := range cves {
+				if _, ok := existFeatures[cve][key]; ok {
+					continue
+				}
+				vulnMap[cve].FixedIn = append(vulnMap[cve].FixedIn, feature)
+				existFeatures[cve][key] = struct{}{}
+			}
+		}
+	}
+
+	vulnerabilities := make([]common.Vulnerability, 0, len(vulnMap))
+	for _, cve := range cves {
+		if len(vulnMap[cve].FixedIn) == 0 {
+			continue
+		}
+		vulnerabilities = append(vulnerabilities, *vulnMap[cve])
+	}
+
+	return vulnerabilities, nil
+}

--- a/updater/fetchers/chainguardv2/chainguardv2_test.go
+++ b/updater/fetchers/chainguardv2/chainguardv2_test.go
@@ -1,0 +1,61 @@
+package chainguardv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAdvisoryFiltersAndDeduplicatesByEcosystem(t *testing.T) {
+	body := []byte(`{
+		"id": "CGA-test-1234",
+		"published": "2026-04-10T00:00:00Z",
+		"modified": "2026-04-11T00:00:00Z",
+		"upstream": ["CVE-2026-0001", "GHSA-test-1234", "CVE-2026-0001"],
+		"affected": [
+			{
+				"package": {"ecosystem": "Wolfi", "name": "haproxy-3.1", "purl": "pkg:apk/wolfi/haproxy-3.1?arch=x86_64"},
+				"ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "3.1.7-r0"}]}]
+			},
+			{
+				"package": {"ecosystem": "Wolfi", "name": "haproxy-3.1", "purl": "pkg:apk/wolfi/haproxy-3.1?arch=aarch64"},
+				"ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "3.1.7-r0"}]}]
+			},
+			{
+				"package": {"ecosystem": "Chainguard", "name": "haproxy-3.1", "purl": "pkg:apk/chainguard/haproxy-3.1?arch=x86_64"},
+				"ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "3.1.8-r0"}]}]
+			},
+			{
+				"package": {"ecosystem": "Wolfi", "name": "haproxy-3.2", "purl": "pkg:apk/wolfi/haproxy-3.2?arch=x86_64"},
+				"ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}]
+			}
+		]
+	}`)
+
+	vulns, err := parseAdvisory(body, "Wolfi", "wolfi:rolling")
+	require.NoError(t, err)
+	require.Len(t, vulns, 1)
+	require.Equal(t, "CVE-2026-0001", vulns[0].Name)
+	require.Equal(t, "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-0001", vulns[0].Link)
+	require.Len(t, vulns[0].FixedIn, 1)
+	require.Equal(t, "wolfi:rolling", vulns[0].FixedIn[0].Feature.Namespace)
+	require.Equal(t, "haproxy-3.1", vulns[0].FixedIn[0].Feature.Name)
+	require.Equal(t, "3.1.7-r0", vulns[0].FixedIn[0].Version.String())
+}
+
+func TestParseAdvisorySkipsEntriesWithoutCVEs(t *testing.T) {
+	body := []byte(`{
+		"id": "CGA-test-5678",
+		"affected": [
+			{
+				"package": {"ecosystem": "Wolfi", "name": "pkg"},
+				"ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "1.0.0-r1"}]}]
+			}
+		],
+		"upstream": ["GHSA-only"]
+	}`)
+
+	vulns, err := parseAdvisory(body, "Wolfi", "wolfi:rolling")
+	require.NoError(t, err)
+	require.Empty(t, vulns)
+}

--- a/updater/fetchers/wolfi/wolfi.go
+++ b/updater/fetchers/wolfi/wolfi.go
@@ -1,130 +1,31 @@
 package wolfi
 
 import (
-	"encoding/json"
-	"io"
-	"net/http"
-	"regexp"
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 
-	"github.com/vul-dbgen/common"
 	"github.com/vul-dbgen/updater"
+	"github.com/vul-dbgen/updater/fetchers/chainguardv2"
 )
 
 const (
-	securityURL  = "https://packages.wolfi.dev/os/security.json"
-	cveURLPrefix = "https://cve.mitre.org/cgi-bin/cvename.cgi?name="
-	// Wolfi uses rolling releases, so we use a generic version identifier
-	wolfiVersion = "rolling"
+	wolfiEcosystem = "Wolfi"
+	wolfiNamespace = "wolfi:rolling"
 )
 
-var cveRegex = regexp.MustCompile(`^CVE-\d{4}-\d{4,}$`)
-
 type WolfiFetcher struct{}
-
-type secDBData struct {
-	Packages []struct {
-		Pkg struct {
-			Name     string                     `json:"name"`
-			SecFixes map[string]json.RawMessage `json:"secfixes"`
-		} `json:"pkg"`
-	} `json:"packages"`
-}
 
 func init() {
 	updater.RegisterFetcher("wolfi", &WolfiFetcher{})
 }
 
-func parseSecDB(body []byte, url string) ([]common.Vulnerability, error) {
-	var data secDBData
-	if err := json.Unmarshal(body, &data); err != nil {
-		log.WithError(err).WithFields(log.Fields{"url": url}).Warn("Failed to unmarshal wolfi db")
-		return nil, err
-	}
-
-	var vulns []common.Vulnerability
-	for _, pkg := range data.Packages {
-		for version, raw := range pkg.Pkg.SecFixes {
-			// Skip version "0" entries as they represent false positives
-			if version == "0" {
-				continue
-			}
-
-			ver, err := common.NewVersion(version)
-			if err != nil {
-				log.WithError(err).WithField("version", version).Warn("Failed to parse package version. skipping")
-				continue
-			}
-
-			var cves []string
-			if err = json.Unmarshal(raw, &cves); err != nil {
-				continue
-			}
-
-			for _, cveName := range cves {
-				// Filter out GHSA identifiers, only process CVEs
-				if !cveRegex.MatchString(cveName) {
-					continue
-				}
-
-				if year, err := common.ParseYear(cveName[4:]); err != nil {
-					log.WithField("cve", cveName).Warn("Unable to parse year from CVE name")
-					continue
-				} else if year < common.FirstYear {
-					continue
-				}
-
-				if s := strings.Index(cveName, " "); s != -1 {
-					cveName = cveName[:s]
-				}
-
-				var vuln common.Vulnerability
-				vuln.Name = cveName
-				vuln.Link = cveURLPrefix + cveName
-
-				featureVersion := common.FeatureVersion{
-					Feature: common.Feature{
-						Namespace: "wolfi:" + wolfiVersion,
-						Name:      pkg.Pkg.Name,
-					},
-					Version: ver,
-				}
-				vuln.FixedIn = append(vuln.FixedIn, featureVersion)
-
-				vulns = append(vulns, vuln)
-
-				common.DEBUG_VULN(&vuln, "wolfi")
-			}
-		}
-	}
-
-	return vulns, nil
-}
-
-func (u *WolfiFetcher) downloadSecDB(url string) ([]common.Vulnerability, error) {
-	r, err := http.Get(url)
-	if err != nil {
-		log.WithError(err).WithFields(log.Fields{"url": url}).Error("Failed to download wolfi db")
-		return nil, err
-	}
-
-	body, _ := io.ReadAll(r.Body)
-	defer r.Body.Close()
-
-	return parseSecDB(body, url)
-}
-
 func (u *WolfiFetcher) FetchUpdate() (resp updater.FetcherResponse, err error) {
 	log.WithField("package", "Wolfi").Info("Start fetching vulnerabilities")
 
-	// Download security.json
-	if vulns, err := u.downloadSecDB(securityURL); err == nil {
-		resp.Vulnerabilities = append(resp.Vulnerabilities, vulns...)
-	} else {
+	vulns, err := chainguardv2.FetchVulnerabilities(wolfiEcosystem, wolfiNamespace)
+	if err != nil {
 		return resp, err
 	}
+	resp.Vulnerabilities = append(resp.Vulnerabilities, vulns...)
 
 	log.WithFields(log.Fields{"Vulnerabilities": len(resp.Vulnerabilities)}).Info("fetching wolfi done")
 	return resp, nil


### PR DESCRIPTION
## Description

https://github.com/chainguard-dev/vulnerability-scanner-support/issues/132#issuecomment-4315407002 mentioned DB gen should also use the OSV v2 feeds, `nothttps://packages.cgr.dev/chainguard/security.json` which is deprecate now. 