### PR TITLE
fix: add openSUSE Leap 15.6 and 16.0 OVAL feed to SUSE fetcher

### DIFF
--- a/updater/fetchers/suse/suse.go
+++ b/updater/fetchers/suse/suse.go
@@ -28,6 +28,8 @@ var (
 		ovalInfo{"suse/suse.linux.enterprise.server.15.xml.gz", "SUSE Linux Enterprise Server 15 ", "sles:"},
 		ovalInfo{"suse/suse.linux.enterprise.server.12.xml.gz", "SUSE Linux Enterprise Server 12 ", "sles:"},
 		ovalInfo{"suse/suse.linux.enterprise.server.11.xml.gz", "SUSE Linux Enterprise Server 11 ", "sles:"},
+		ovalInfo{"suse/opensuse.leap.16.0.xml.gz", "openSUSE Leap 16.0 ", "sles:l"},
+		ovalInfo{"suse/opensuse.leap.15.6.xml.gz", "openSUSE Leap 15.6 ", "sles:l"},
 		ovalInfo{"suse/opensuse.leap.15.5.xml.gz", "openSUSE Leap 15.5 ", "sles:l"},
 		ovalInfo{"suse/opensuse.leap.15.4.xml.gz", "openSUSE Leap 15.4 ", "sles:l"},
 		ovalInfo{"suse/opensuse.leap.15.3.xml.gz", "openSUSE Leap 15.3 ", "sles:l"},


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #XXX

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
